### PR TITLE
Update the codes of demo based on the list of issue

### DIFF
--- a/demo/FIR.py
+++ b/demo/FIR.py
@@ -5,13 +5,8 @@ import time
 import argparse
 import os
 import matplotlib.pyplot as plt
-
-from jax_startup.filter import gaussian_kernal, FIR_filter_np, FIR_filter_jax
-
-
-# Define Gaussian filter
-
-
+from jax import numpy as jnp
+import jax_startup.filter as filter
 
 if __name__ == '__main__':
     # Set up argument parser for image, which needs to be filtered.
@@ -23,6 +18,15 @@ if __name__ == '__main__':
     # Splits the filename into the base filename and its extension.
     filename, _ = os.path.splitext(os.path.basename(args.image_path))
 
+    # Get the available devices
+    available_devices = jax.devices()
+
+    # Print available devices
+    print("Available devices:", available_devices)
+
+    # Check if any GPU is available, else default to CPU
+    selected_device = next((device for device in available_devices if device.platform == 'gpu'), available_devices[0])
+
     # Load the image and convert to grayscale
     image = np.array(Image.open(args.image_path).convert('L')).astype('float')
 
@@ -31,36 +35,47 @@ if __name__ == '__main__':
     N = 2*P +1
 
     # Generate Gaussian filter
-    kernel = gaussian_kernal(P, sigma=5)
+    kernel = filter.gaussian_kernel(P, sigma=5)
 
     # Run FIR filtering.
     # Time and apply filtering using NumPy
     start_time = time.time()
-    numpy_output = FIR_filter_np(image, kernel)
+    numpy_output = filter.FIR_filter_np(image, kernel)
     numpy_duration = time.time() - start_time
     print(f"Numpy filter time: {numpy_duration:.4f} seconds")
 
-    # Time and apply filtering using JAX
+    # Convert the image and kernel to JAX array
+    image = jnp.array(image)
+    kernel = jnp.array(kernel)
+
+    # Time and apply filtering using JAX with vmap
     start_time = time.time()
-    jax_output_vmap = jax.jit(FIR_filter_jax, device=jax.devices('cpu')[0])(image, kernel)
+    jax_output_vmap = jax.jit(filter.FIR_filter_jax, device=selected_device)(image, kernel)
     jax_duration = time.time() - start_time
     print(f"Jax filter with vmap time: {jax_duration:.4f} seconds")
 
-    # Time and apply filtering using JAX
+    # Time and apply filtering using JAX with pmap
     start_time = time.time()
-    jax_output_pmap = FIR_filter_jax(image, kernel, map_method='pmap')
+    jax_output_pmap = filter.FIR_filter_jax(image, kernel, map_method='pmap')
     jax_duration = time.time() - start_time
     print(f"Jax filter with pmap time: {jax_duration:.4f} seconds")
+
+    # Time and apply filtering using JAX's built-in convolution
+    start_time = time.time()
+    jax_output_builtin = filter.FIR_filter_jax_builtin(image, kernel)
+    jax_duration = time.time() - start_time
+    print(f"Jax filter with built-in convolution time: {jax_duration:.4f} seconds")
 
     # Save result figures.
     # Make an output folder and save both ground truth and filtered figures.
     output_dir = "./output"
     os.makedirs(output_dir, exist_ok=True)
     print("Save to %s" % output_dir)
-    Image.fromarray(image.astype(np.uint8)).save(os.path.join(output_dir, filename + "_gt.png"))
+    Image.fromarray(np.array(image).astype(np.uint8)).save(os.path.join(output_dir, filename + "_gt.png"))
     Image.fromarray(numpy_output.astype(np.uint8)).save(os.path.join(output_dir, filename + "_numpy_output.png"))
     Image.fromarray(np.array(jax_output_vmap).astype(np.uint8)).save(os.path.join(output_dir, filename + "_jaxvmap_output.png"))
     Image.fromarray(np.array(jax_output_pmap).astype(np.uint8)).save(os.path.join(output_dir, filename + "_jaxpmap_output.png"))
+    Image.fromarray(np.array(jax_output_builtin).astype(np.uint8)).save(os.path.join(output_dir, filename + "_jaxbuiltin_output.png"))
 
     # Display
     # Determine the size of the patch you want to display
@@ -76,19 +91,36 @@ if __name__ == '__main__':
     x_end = x_start + patch_size_x
 
     # Display results using Matplotlib
-    fig, axes = plt.subplots(2, 2, figsize=(12, 10))
-    axes[0, 0].imshow(image.astype(np.uint8)[y_start:y_end, x_start:x_end], cmap='gray')
+    fig, axes = plt.subplots(2, 3, figsize=(18, 10))
+
+    # Original Image
+    axes[0, 0].imshow(np.array(image).astype(np.uint8)[y_start:y_end, x_start:x_end], cmap='gray')
     axes[0, 0].set_title("Original Image")
     axes[0, 0].axis('off')
+
+    # Filtered (NumPy)
     axes[0, 1].imshow(numpy_output.astype(np.uint8)[y_start:y_end, x_start:x_end], cmap='gray')
     axes[0, 1].set_title("Filtered (NumPy)")
     axes[0, 1].axis('off')
-    axes[1, 0].imshow(np.array(jax_output_vmap).astype(np.uint8)[y_start:y_end, x_start:x_end], cmap='gray')
-    axes[1, 0].set_title("Filtered (JAX-Vmap)")
+
+    # Filtered (JAX-Vmap)
+    axes[0, 2].imshow(np.array(jax_output_vmap).astype(np.uint8)[y_start:y_end, x_start:x_end], cmap='gray')
+    axes[0, 2].set_title("Filtered (JAX-Vmap)")
+    axes[0, 2].axis('off')
+
+    # Filtered (JAX-Pmap)
+    axes[1, 0].imshow(np.array(jax_output_pmap).astype(np.uint8)[y_start:y_end, x_start:x_end], cmap='gray')
+    axes[1, 0].set_title("Filtered (JAX-Pmap)")
     axes[1, 0].axis('off')
-    axes[1, 1].imshow(np.array(jax_output_pmap).astype(np.uint8)[y_start:y_end, x_start:x_end], cmap='gray')
-    axes[1, 1].set_title("Filtered (JAX-Pmap)")
+
+    # Filtered (JAX-Built-in)
+    axes[1, 1].imshow(np.array(jax_output_builtin).astype(np.uint8)[y_start:y_end, x_start:x_end], cmap='gray')
+    axes[1, 1].set_title("Filtered (JAX-Built-in)")
     axes[1, 1].axis('off')
+
+    # Hide the last subplot
+    axes[1, 2].axis('off')
+
     plt.tight_layout()
     plt.show()
 


### PR DESCRIPTION
This PR includes:

- Converted all NumPy arrays to JAX arrays before passing them to JAX functions.
- Included an example of using the built-in JAX convolution function in the demo.
- Flipped the kernels to perform convolution instead of correlation.
- Corrected the typo of "kenal" to "kernel."
- Other small improvements on the details.